### PR TITLE
remove max retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ To generate or update documentation, run `go generate`.
 In order to run the full suite of Acceptance tests, run `make testacc`.
 
 ```shell
-make testacc
+make test
 ```

--- a/docs/resources/http_health.md
+++ b/docs/resources/http_health.md
@@ -17,9 +17,6 @@ resource "checkmate_http_health" "example" {
   # This is the url of the endpoint we want to check
   url = "http://example.com"
 
-  # We're willing to try up to 10 times
-  retries = 10
-
   # Will perform an HTTP GET request
   method = "GET"
 
@@ -43,7 +40,6 @@ resource "checkmate_http_health" "example" {
 
 resource "checkmate_http_health" "example_ca_bundle" {
   url                   = "https://untrusted-root.badssl.com/"
-  retries               = 10
   method                = "GET"
   interval              = 1
   status_code           = 200
@@ -53,7 +49,6 @@ resource "checkmate_http_health" "example_ca_bundle" {
 
 resource "checkmate_http_health" "example_no_ca_bundle" {
   url                   = "https://httpbin.org/status/200"
-  retries               = 10
   request_timeout       = 1000
   method                = "GET"
   interval              = 1
@@ -63,7 +58,6 @@ resource "checkmate_http_health" "example_no_ca_bundle" {
 
 resource "checkmate_http_health" "example_insecure_tls" {
   url                   = "https://self-signed.badssl.com/"
-  retries               = 10
   request_timeout       = 1000
   method                = "GET"
   interval              = 1
@@ -90,8 +84,6 @@ resource "checkmate_http_health" "example_insecure_tls" {
 - `interval` (Number) Interval in milliseconds between attemps. Default 200
 - `method` (String) HTTP Method, defaults to GET
 - `request_timeout` (Number) Timeout for an individual request. If exceeded, the attempt will be considered failure and potentially retried. Default 1000
-- `retries` (Number) Max number of times to retry a failure. Exceeding this number will cause the check to fail even if timeout has not expired yet.
- Default 5.
 - `status_code` (String) Status Code to expect. Default 200
 - `timeout` (Number) Overall timeout in milliseconds for the check before giving up. Default 5000
 

--- a/docs/resources/local_command.md
+++ b/docs/resources/local_command.md
@@ -20,9 +20,6 @@ resource "checkmate_local_command" "example" {
   # Switch to this directory before running the command
   working_directory = "./scripts"
 
-  # We're willing to try up to 10 times
-  retries = 5
-
   # The overall test should not take longer than 5 seconds
   timeout = 5000
 
@@ -48,8 +45,6 @@ resource "checkmate_local_command" "example" {
 - `consecutive_successes` (Number) Number of consecutive successes required before the check is considered successful overall. Defaults to 1.
 - `create_anyway_on_check_failure` (Boolean) If false, the resource will fail to create if the check does not pass. If true, the resource will be created anyway. Defaults to false.
 - `interval` (Number) Interval in milliseconds between attemps. Default 200
-- `retries` (Number) Max number of times to retry a failure. Exceeding this number will cause the check to fail even if timeout has not expired yet.
- Default 5.
 - `timeout` (Number) Overall timeout in milliseconds for the check before giving up, default 10000
 - `working_directory` (String) Working directory where the command will be run. Defaults to the current working directory
 

--- a/examples/resources/checkmate_http_health/resource.tf
+++ b/examples/resources/checkmate_http_health/resource.tf
@@ -2,9 +2,6 @@ resource "checkmate_http_health" "example" {
   # This is the url of the endpoint we want to check
   url = "http://example.com"
 
-  # We're willing to try up to 10 times
-  retries = 10
-
   # Will perform an HTTP GET request
   method = "GET"
 
@@ -28,7 +25,6 @@ resource "checkmate_http_health" "example" {
 
 resource "checkmate_http_health" "example_ca_bundle" {
   url                   = "https://untrusted-root.badssl.com/"
-  retries               = 10
   method                = "GET"
   interval              = 1
   status_code           = 200
@@ -38,7 +34,6 @@ resource "checkmate_http_health" "example_ca_bundle" {
 
 resource "checkmate_http_health" "example_no_ca_bundle" {
   url                   = "https://httpbin.org/status/200"
-  retries               = 10
   request_timeout       = 1000
   method                = "GET"
   interval              = 1
@@ -48,7 +43,6 @@ resource "checkmate_http_health" "example_no_ca_bundle" {
 
 resource "checkmate_http_health" "example_insecure_tls" {
   url                   = "https://self-signed.badssl.com/"
-  retries               = 10
   request_timeout       = 1000
   method                = "GET"
   interval              = 1

--- a/examples/resources/checkmate_local_command/resource.tf
+++ b/examples/resources/checkmate_local_command/resource.tf
@@ -5,9 +5,6 @@ resource "checkmate_local_command" "example" {
   # Switch to this directory before running the command
   working_directory = "./scripts"
 
-  # We're willing to try up to 10 times
-  retries = 5
-
   # The overall test should not take longer than 5 seconds
   timeout = 5000
 


### PR DESCRIPTION
It's an overengineering at this point, and a "nice to have" at most. So, remove the "fail quickly if max retries exceeded", and do only the "fail when the timeout expired". After all, the timeout and retry delay implicitly give the max retries already.