### PR TITLE
Add checkmate_tcp_echo resource

### DIFF
--- a/examples/resources/checkmate_tcp_echo/resource.tf
+++ b/examples/resources/checkmate_tcp_echo/resource.tf
@@ -1,0 +1,22 @@
+resource "checkmate_tcp_echo" "example" {
+  # The hostname where the echo request will be sent
+  host = "foo.bar"
+
+  # The TCP port at which the request will be sent
+  port = 3002
+
+  # Message that will be sent to the TCP echo server
+  message = "PROXY tcpbin.com:4242 foobartest"
+
+  # Message expected to be present in the echo response
+  expected_message = "foobartest"
+
+  # Set the connection timeout for the destination host, in milliseconds
+  connection_timeout = 3000
+
+  # Set the per try timeout for the destination host, in milliseconds
+  single_attempt_timeout = 2000
+
+  # Set a number of consecutive sucesses to make the check pass
+  consecutive_successes = 5
+}

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.18.1 // indirect
 	github.com/hashicorp/terraform-json v0.16.0 // indirect
+	github.com/hashicorp/terraform-plugin-framework-validators v0.10.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.1.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/hashicorp/terraform-plugin-docs v0.14.1 h1:MikFi59KxrP/ewrZoaowrB9he5
 github.com/hashicorp/terraform-plugin-docs v0.14.1/go.mod h1:k2NW8+t113jAus6bb5tQYQgEAX/KueE/u8X2Z45V1GM=
 github.com/hashicorp/terraform-plugin-framework v1.2.0 h1:MZjFFfULnFq8fh04FqrKPcJ/nGpHOvX4buIygT3MSNY=
 github.com/hashicorp/terraform-plugin-framework v1.2.0/go.mod h1:nToI62JylqXDq84weLJ/U3umUsBhZAaTmU0HXIVUOcw=
+github.com/hashicorp/terraform-plugin-framework-validators v0.10.0 h1:4L0tmy/8esP6OcvocVymw52lY0HyQ5OxB7VNl7k4bS0=
+github.com/hashicorp/terraform-plugin-framework-validators v0.10.0/go.mod h1:qdQJCdimB9JeX2YwOpItEu+IrfoJjWQ5PhLpAOMDQAE=
 github.com/hashicorp/terraform-plugin-go v0.14.3 h1:nlnJ1GXKdMwsC8g1Nh05tK2wsC3+3BL/DBBxFEki+j0=
 github.com/hashicorp/terraform-plugin-go v0.14.3/go.mod h1:7ees7DMZ263q8wQ6E4RdIdR6nHHJtrdt4ogX5lPkX1A=
 github.com/hashicorp/terraform-plugin-log v0.8.0 h1:pX2VQ/TGKu+UU1rCay0OlzosNKe4Nz1pepLXj95oyy0=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -56,6 +56,7 @@ func (p *CheckmateProvider) Resources(ctx context.Context) []func() resource.Res
 	return []func() resource.Resource{
 		NewHttpHealthResource,
 		NewLocalCommandResource,
+		NewTCPEchoResource,
 	}
 }
 

--- a/internal/provider/resource_http_health_test.go
+++ b/internal/provider/resource_http_health_test.go
@@ -24,6 +24,7 @@ import (
 
 func TestAccHttpHealthResource(t *testing.T) {
 	// testUrl := "http://example.com"
+	httpBinTimeout := 60000 // 60s
 	testUrl := "https://httpbin.org/status/200"
 
 	resource.Test(t, resource.TestCase{
@@ -32,19 +33,19 @@ func TestAccHttpHealthResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccHttpHealthResourceConfig("test", testUrl),
+				Config: testAccHttpHealthResourceConfig("test", testUrl, httpBinTimeout),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("checkmate_http_health.test", "url", testUrl),
 				),
 			},
 			{
-				Config: testAccHttpHealthResourceConfig("test_headers", "https://httpbin.org/headers"),
+				Config: testAccHttpHealthResourceConfig("test_headers", "https://httpbin.org/headers", httpBinTimeout),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrWith("checkmate_http_health.test_headers", "result_body", checkHeader("Hello", "world")),
 				),
 			},
 			{
-				Config: testAccHttpHealthResourceConfigWithBody("test_post", "https://httpbin.org/post", "hello"),
+				Config: testAccHttpHealthResourceConfigWithBody("test_post", "https://httpbin.org/post", "hello", httpBinTimeout),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrWith("checkmate_http_health.test_post", "result_body", checkResponse("hello")),
 				),
@@ -67,7 +68,7 @@ func TestAccHttpHealthResource(t *testing.T) {
 	})
 }
 
-func testAccHttpHealthResourceConfig(name string, url string) string {
+func testAccHttpHealthResourceConfig(name string, url string, timeout int) string {
 	return fmt.Sprintf(`
 resource "checkmate_http_health" %[1]q {
   url = %[2]q
@@ -75,10 +76,11 @@ resource "checkmate_http_health" %[1]q {
   headers = {
 	hello = "world"
   }
+  timeout = %[3]d
 }
-`, name, url)
+`, name, url, timeout)
 }
-func testAccHttpHealthResourceConfigWithBody(name string, url string, body string) string {
+func testAccHttpHealthResourceConfigWithBody(name string, url string, body string, timeout int) string {
 	return fmt.Sprintf(`
 resource "checkmate_http_health" %[1]q {
   url = %[2]q
@@ -88,8 +90,9 @@ resource "checkmate_http_health" %[1]q {
 	"Content-Type" = "application/text"
   }
   request_body = %[3]q
+  timeout = %[4]d
 }
-`, name, url, body)
+`, name, url, body, timeout)
 
 }
 

--- a/internal/provider/resource_tcp_echo.go
+++ b/internal/provider/resource_tcp_echo.go
@@ -1,0 +1,268 @@
+// Copyright 2023 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/tetratelabs/terraform-provider-checkmate/internal/helpers"
+	"github.com/tetratelabs/terraform-provider-checkmate/internal/modifiers"
+)
+
+var _ resource.Resource = &TCPEchoResource{}
+var _ resource.ResourceWithImportState = &TCPEchoResource{}
+
+type TCPEchoResource struct{}
+
+// Schema implements resource.Resource
+func (*TCPEchoResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "TCP Echo",
+
+		Attributes: map[string]schema.Attribute{
+			"host": schema.StringAttribute{
+				MarkdownDescription: "The hostname where to send the TCP echo request to",
+				Required:            true,
+			},
+			"port": schema.Int64Attribute{
+				MarkdownDescription: "The port of the hostname where to send the TCP echo request",
+				Required:            true,
+				Validators: []validator.Int64{
+					int64validator.Between(1, 65535),
+				},
+			},
+			"message": schema.StringAttribute{
+				MarkdownDescription: "The message to send in the echo request",
+				Required:            true,
+			},
+			"expected_message": schema.StringAttribute{
+				MarkdownDescription: "The message expected to be included in the echo response",
+				Required:            true,
+			},
+			"timeout": schema.Int64Attribute{
+				MarkdownDescription: "Overall timeout in milliseconds for the check before giving up, default 10000",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers:       []planmodifier.Int64{modifiers.DefaultInt64(10000)},
+			},
+			"connection_timeout": schema.Int64Attribute{
+				MarkdownDescription: "The timeout for stablishing a new TCP connection in milliseconds",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers:       []planmodifier.Int64{modifiers.DefaultInt64(5000)},
+			},
+			"single_attempt_timeout": schema.Int64Attribute{
+				MarkdownDescription: "Timeout for an individual attempt. If exceeded, the attempt will be considered failure and potentially retried. Default 5000ms",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers:       []planmodifier.Int64{modifiers.DefaultInt64(5000)},
+			},
+			"interval": schema.Int64Attribute{
+				MarkdownDescription: "Interval in milliseconds between attemps. Default 200",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers:       []planmodifier.Int64{modifiers.DefaultInt64(200)},
+			},
+			"consecutive_successes": schema.Int64Attribute{
+				MarkdownDescription: "Number of consecutive successes required before the check is considered successful overall. Defaults to 1.",
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers:       []planmodifier.Int64{modifiers.DefaultInt64(1)},
+			},
+			"passed": schema.BoolAttribute{
+				Computed:            true,
+				MarkdownDescription: "True if the check passed",
+			},
+			"create_anyway_on_check_failure": schema.BoolAttribute{
+				Optional:            true,
+				MarkdownDescription: "If false, the resource will fail to create if the check does not pass. If true, the resource will be created anyway. Defaults to false.",
+			},
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Identifier",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"keepers": schema.MapAttribute{
+				ElementType:         types.StringType,
+				MarkdownDescription: "Arbitrary map of string values that when changed will cause the check to run again.",
+				Optional:            true,
+			},
+		}}
+}
+
+type TCPEchoResourceModel struct {
+	Id                   types.String `tfsdk:"id"`
+	Host                 types.String `tfsdk:"host"`
+	Port                 types.Int64  `tfsdk:"port"`
+	Message              types.String `tfsdk:"message"`
+	ExpectedMessage      types.String `tfsdk:"expected_message"`
+	ConnectionTimeout    types.Int64  `tfsdk:"connection_timeout"`
+	SingleAttemptTimeout types.Int64  `tfsdk:"single_attempt_timeout"`
+	Timeout              types.Int64  `tfsdk:"timeout"`
+	Interval             types.Int64  `tfsdk:"interval"`
+	ConsecutiveSuccesses types.Int64  `tfsdk:"consecutive_successes"`
+	IgnoreFailure        types.Bool   `tfsdk:"create_anyway_on_check_failure"`
+	Passed               types.Bool   `tfsdk:"passed"`
+	Keepers              types.Map    `tfsdk:"keepers"`
+}
+
+// ImportState implements resource.ResourceWithImportState
+func (*TCPEchoResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// Create implements resource.Resource
+func (r *TCPEchoResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data TCPEchoResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Id = types.StringValue(uuid.NewString())
+
+	r.TCPEcho(ctx, &data, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
+}
+
+func (r *TCPEchoResource) TCPEcho(ctx context.Context, data *TCPEchoResourceModel, diag *diag.Diagnostics) {
+	data.Passed = types.BoolValue(false)
+
+	window := helpers.RetryWindow{
+		Timeout:              time.Duration(data.Timeout.ValueInt64()) * time.Millisecond,
+		Interval:             time.Duration(data.Interval.ValueInt64()) * time.Millisecond,
+		ConsecutiveSuccesses: int(data.ConsecutiveSuccesses.ValueInt64()),
+	}
+
+	result := window.Do(func(attempt int, success int) bool {
+		destStr := data.Host.ValueString() + ":" + strconv.Itoa(int(data.Port.ValueInt64()))
+
+		d := net.Dialer{Timeout: time.Duration(data.ConnectionTimeout.ValueInt64()) * time.Millisecond}
+		conn, err := d.Dial("tcp", destStr)
+		if err != nil {
+			diag.AddWarning(fmt.Sprintf("dial %q failed", destStr), err.Error())
+			return false
+		}
+		defer conn.Close()
+
+		_, err = conn.Write([]byte(data.Message.ValueString() + "\n"))
+		if err != nil {
+			diag.AddWarning("write to server failed", err.Error())
+			return false
+		}
+
+		deadlineDuration := time.Millisecond * time.Duration(data.SingleAttemptTimeout.ValueInt64())
+		err = conn.SetDeadline(time.Now().Add(deadlineDuration))
+		if err != nil {
+			diag.AddWarning("could not set connection deadline", err.Error())
+			return false
+		}
+
+		reply := make([]byte, 1024)
+		_, err = conn.Read(reply)
+		if err != nil {
+			diag.AddWarning("read from server failed", err.Error())
+			return false
+		}
+
+		if !strings.Contains(string(reply), data.ExpectedMessage.ValueString()) {
+			diag.AddWarning("unexpected response", fmt.Sprintf("Got response %q, which does not include expected message %q", string(reply), data.ExpectedMessage.ValueString()))
+			return false
+		}
+
+		return true
+	})
+
+	switch result {
+	case helpers.Success:
+		data.Passed = types.BoolValue(true)
+	case helpers.TimeoutExceeded:
+		diag.AddWarning("Timeout exceeded", fmt.Sprintf("Timeout of %d milliseconds exceeded", data.Timeout.ValueInt64()))
+		if !data.IgnoreFailure.ValueBool() {
+			diag.AddError("Check failed", "The check did not pass and create_anyway_on_check_failure is false")
+			return
+		}
+	}
+
+}
+
+// Delete implements resource.Resource
+func (*TCPEchoResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data *TCPEchoResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Metadata implements resource.Resource
+func (*TCPEchoResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_tcp_echo"
+}
+
+// Read implements resource.Resource
+func (*TCPEchoResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *TCPEchoResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// Update implements resource.Resource
+func (r *TCPEchoResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *TCPEchoResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	r.TCPEcho(ctx, data, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func NewTCPEchoResource() resource.Resource {
+	return &TCPEchoResource{}
+}

--- a/internal/provider/resource_tcp_echo_test.go
+++ b/internal/provider/resource_tcp_echo_test.go
@@ -1,0 +1,52 @@
+// Copyright 2023 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccTCPEchoResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTCPEchoResourceConfig("test_success", "true", false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("checkmate_tcp_echo.test_success", "passed", "true"),
+				),
+			},
+			{
+				Config: testAccTCPEchoResourceConfig("test_failure", "false", true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("checkmate_tcp_echo.test_failure", "passed", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTCPEchoResourceConfig(name string, command string, ignore_failure bool) string {
+	return fmt.Sprintf(`
+resource "checkmate_tcp_echo" %[1]q {
+	command = %[2]q
+	create_anyway_on_check_failure = %[3]t
+}`, name, command, ignore_failure)
+
+}

--- a/internal/provider/resource_tcp_echo_test.go
+++ b/internal/provider/resource_tcp_echo_test.go
@@ -27,13 +27,13 @@ func TestAccTCPEchoResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTCPEchoResourceConfig("test_success", "true", false),
+				Config: testAccTCPEchoResourceConfig("test_success", "tcpbin.com", 4242, "foobar", "foobar", false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("checkmate_tcp_echo.test_success", "passed", "true"),
 				),
 			},
 			{
-				Config: testAccTCPEchoResourceConfig("test_failure", "false", true),
+				Config: testAccTCPEchoResourceConfig("test_failure", "foo.bar", 1234, "foobar", "foobar", true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("checkmate_tcp_echo.test_failure", "passed", "false"),
 				),
@@ -42,11 +42,14 @@ func TestAccTCPEchoResource(t *testing.T) {
 	})
 }
 
-func testAccTCPEchoResourceConfig(name string, command string, ignore_failure bool) string {
+func testAccTCPEchoResourceConfig(name, host string, port int, message, expected_message string, ignore_failure bool) string {
 	return fmt.Sprintf(`
-resource "checkmate_tcp_echo" %[1]q {
-	command = %[2]q
-	create_anyway_on_check_failure = %[3]t
-}`, name, command, ignore_failure)
+resource "checkmate_tcp_echo" %q {
+	host = %q
+	port = %d
+	message = %q
+	expected_message = %q
+	create_anyway_on_check_failure = %t
+}`, name, host, port, message, expected_message, ignore_failure)
 
 }


### PR DESCRIPTION
Add a TCP echo check resource. Sends a `message` to a destination `host:port` and expects `expected_message` to be included in the response.