### PR TITLE
Add persistent_response_regex to tcp echo check

### DIFF
--- a/docs/resources/tcp_echo.md
+++ b/docs/resources/tcp_echo.md
@@ -81,6 +81,12 @@ resource "checkmate_tcp_echo" "example" {
 - `expected_message` (String) The message expected to be included in the echo response
 - `interval` (Number) Interval in milliseconds between attemps. Default 200
 - `keepers` (Map of String) Arbitrary map of string values that when changed will cause the check to run again.
+- `persistent_response_regex` (String) A regex pattern that the response need to match in every attempt to be considered successful.
+  If not provided, the response is not checked.
+
+  If using multiple attempts, this regex will be evaulated against the response text. For every susequent attempt, the regex
+  will be evaluated against the response text and compared against the first obtained value. The check will be deemed successful
+  if the regex matches the response text in every attempt. A single response not matching such value will cause the check to fail.
 - `single_attempt_timeout` (Number) Timeout for an individual attempt. If exceeded, the attempt will be considered failure and potentially retried. Default 5000ms
 - `timeout` (Number) Overall timeout in milliseconds for the check before giving up, default 10000
 

--- a/pkg/provider/resource_tcp_echo.go
+++ b/pkg/provider/resource_tcp_echo.go
@@ -77,11 +77,11 @@ func (*TCPEchoResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			},
 			"persistent_response_regex": schema.StringAttribute{
 				MarkdownDescription: `A regex pattern that the response need to match in every attempt to be considered successful.
-If not provided, the response is not checked.
+  If not provided, the response is not checked.
 
-If using multiple attempts, this regex will be evaulated against the response text. For every susequent attempt, the regex
-will be evaluated against the response text and compared against the first obtained value. The check will be deemed successful
-if the regex matches the response text in every attempt. A single response not matching such value will cause the check to fail.`,
+  If using multiple attempts, this regex will be evaulated against the response text. For every susequent attempt, the regex
+  will be evaluated against the response text and compared against the first obtained value. The check will be deemed successful
+  if the regex matches the response text in every attempt. A single response not matching such value will cause the check to fail.`,
 				Required: false,
 				Optional: true,
 				Computed: true,

--- a/pkg/provider/resource_tcp_echo_test.go
+++ b/pkg/provider/resource_tcp_echo_test.go
@@ -38,6 +38,24 @@ func TestAccTCPEchoResource(t *testing.T) {
 					resource.TestCheckResourceAttr("checkmate_tcp_echo.test_failure", "passed", "false"),
 				),
 			},
+			{
+				Config: testAccTCPEchoResourceConfig("test_failure", "foo.bar", 1234, "foobar", "foobar", true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("checkmate_tcp_echo.test_failure", "passed", "false"),
+				),
+			},
+			{
+				Config: testTCPEchoResourceRegex("test_regex_ok", `\(.*\)`, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("checkmate_tcp_echo.test_regex_ok", "passed", "true"),
+				),
+			},
+			{
+				Config: testTCPEchoResourceRegex("test_regex_not_match_pass_anyway", "test", true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("checkmate_tcp_echo.test_regex_not_match_pass_anyway", "passed", "false"),
+				),
+			},
 		},
 	})
 }
@@ -52,5 +70,20 @@ resource "checkmate_tcp_echo" %q {
 	expected_message = %q
 	create_anyway_on_check_failure = %t
 }`, name, host, port, message, expected_message, ignore_failure)
+
+}
+
+func testTCPEchoResourceRegex(name, regex string, ignore_failure bool) string {
+	return fmt.Sprintf(`
+resource "checkmate_tcp_echo" %q {
+	host = "tcpecho.platform.tetrate.com"
+	port = 15080
+	message = "foobar (123)"
+	timeout = 1000 * 10
+	expected_message = "foobar (123)"
+	persistent_response_regex = %q
+	create_anyway_on_check_failure = %t
+	consecutive_successes = 2
+}`, name, regex, ignore_failure)
 
 }


### PR DESCRIPTION
`persistent_response_regex` is a regex that will be matched against the echo response. 

- If the response does not match the regex, the check fails.
- If there is a single attempt configured and the regex matches, the test passes.
- If there are multiple attempts, the check will pass if all the responses have the same match as the first one.